### PR TITLE
Remove uses_defaults from ServiceProviderConfig endpoint

### DIFF
--- a/app/controllers/scimitar/service_provider_configurations_controller.rb
+++ b/app/controllers/scimitar/service_provider_configurations_controller.rb
@@ -1,7 +1,9 @@
 module Scimitar
   class ServiceProviderConfigurationsController < ApplicationController
     def show
-      render json: Scimitar.service_provider_configuration(location: request.url)
+      service_provider_configuration = Scimitar.service_provider_configuration(location: request.url).as_json
+      service_provider_configuration.delete("uses_defaults")
+      render json: service_provider_configuration
     end
   end
 end

--- a/spec/controllers/scimitar/service_provider_configurations_controller_spec.rb
+++ b/spec/controllers/scimitar/service_provider_configurations_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Scimitar::ServiceProviderConfigurationsController do
 
       expect(response).to be_ok
       expect(JSON.parse(response.body)).to include('patch' => {'supported' => true})
+      expect(JSON.parse(response.body)).to_not include('uses_defaults' => true)
       expect(JSON.parse(response.body)).to include('filter' => {'maxResults' => Scimitar::Filter::MAX_RESULTS_DEFAULT, 'supported' => true})
     end
   end


### PR DESCRIPTION
This PR remove the `uses_defaults` attribute when return the JSON at the `/ServiceProviderConfig`. The response is now according to the schema as defined in https://datatracker.ietf.org/doc/html/rfc7643#section-5.

Find the discussion at https://github.com/RIPAGlobal/scimitar/issues/144.