### PR TITLE
Address issue with PATCH payload and complex attributes on the extension schemas

### DIFF
--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -990,8 +990,12 @@ module Scimitar
             end
 
             found_data_for_recursion.each do | found_data |
+              extension_schema = self.class.scim_resource_type&.schemas&.detect { |schema| schema.id == path_component }
+
               attr_map = if path_component.to_sym == :root
                 with_attr_map
+              elsif extension_schema
+                with_attr_map.slice(*extension_schema.scim_attributes.map { |attr| attr.name.to_sym })
               else
                 with_attr_map[path_component.to_sym]
               end


### PR DESCRIPTION
### Issue
We have an extension schema that uses complex type attributes and currently `PATCH` requests fail if operation payload features `path` key pointing to such attribute instead of referring to it as part of `value` payload, i.e.:
```
{
  op: "replace",
  path: "urn:ietf:params:scim:schemas:extension:my_cool_schema:1.0:User:my_complex_attribute",
  value: {
    sub_attribute_1: "oh",
    sub_attribute_2: "no"
  }
}
```

The issue is with attributes map for this case where an additional lookup for the extension schema is needed.

#### Note
I decided to add temporary extension schema in spec to test this case in isolation, but otherwise requires updating a lot in specs.